### PR TITLE
Use fullname

### DIFF
--- a/avro_json_serializer/__init__.py
+++ b/avro_json_serializer/__init__.py
@@ -114,7 +114,7 @@ class AvroJsonSerializer(object):
                 else:
                     field_type_name = candiate_schema.type
                     if isinstance(candiate_schema, avro.schema.NamedSchema):
-                        field_type_name = candiate_schema.name
+                        field_type_name = candiate_schema.fullname
                     return {
                         field_type_name: self._serialize_data(candiate_schema, datum)
                     }

--- a/avro_json_serializer/test/test_avro_json_serializer.py
+++ b/avro_json_serializer/test/test_avro_json_serializer.py
@@ -96,6 +96,7 @@ class TestAvroJsonSerializer(TestCase):
         "type": [
             {
                 "type": "record",
+                "namespace": "example.avro",
                 "name": "rec1",
                 "fields": [
                     {
@@ -106,6 +107,7 @@ class TestAvroJsonSerializer(TestCase):
             },
             {
                 "type": "record",
+                "namespace": "example.avro",
                 "name": "rec2",
                 "fields": [
                     {
@@ -206,7 +208,7 @@ class TestAvroJsonSerializer(TestCase):
             }
         }
         avro_json = AvroJsonSerializer(avro_schema).to_json(data)
-        self.assertEquals(avro_json, """{"funion_rec":{"rec1":{"field":1}}}""")
+        self.assertEquals(avro_json, """{"funion_rec":{"example.avro.rec1":{"field":1}}}""")
 
         data_another_record = {
             "funion_rec": {
@@ -214,7 +216,7 @@ class TestAvroJsonSerializer(TestCase):
             }
         }
         another_record_json = AvroJsonSerializer(avro_schema).to_json(data_another_record)
-        self.assertEquals(another_record_json, """{"funion_rec":{"rec2":{"field":"hi"}}}""")
+        self.assertEquals(another_record_json, """{"funion_rec":{"example.avro.rec2":{"field":"hi"}}}""")
 
     def test_map(self):
         schema_dict = {


### PR DESCRIPTION
Using fullname makes this serializer more consistent with json serialization of java version of avro.
