### PR TITLE
fullname and python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 venv/
 .idea/
 *.iml
+.tox/

--- a/avro_json_serializer/__init__.py
+++ b/avro_json_serializer/__init__.py
@@ -122,7 +122,10 @@ class AvroJsonSerializer(object):
                 else:
                     field_type_name = candiate_schema.type
                     if isinstance(candiate_schema, avro.schema.NamedSchema):
-                        field_type_name = candiate_schema.fullname
+                        if candiate_schema.namespace:
+                            field_type_name = candiate_schema.fullname
+                        else:
+                            field_type_name = candiate_schema.name
                     return {
                         field_type_name: self._serialize_data(candiate_schema, datum)
                     }

--- a/avro_json_serializer/__init__.py
+++ b/avro_json_serializer/__init__.py
@@ -122,7 +122,7 @@ class AvroJsonSerializer(object):
                 else:
                     field_type_name = candiate_schema.type
                     if isinstance(candiate_schema, avro.schema.NamedSchema):
-                        field_type_name = candiate_schema.name
+                        field_type_name = candiate_schema.fullname
                     return {
                         field_type_name: self._serialize_data(candiate_schema, datum)
                     }

--- a/avro_json_serializer/test/test_avro_json_serializer.py
+++ b/avro_json_serializer/test/test_avro_json_serializer.py
@@ -103,6 +103,7 @@ class TestAvroJsonSerializer(TestCase):
         "type": [
             {
                 "type": "record",
+                "namespace": "example.avro",
                 "name": "rec1",
                 "fields": [
                     {
@@ -113,6 +114,7 @@ class TestAvroJsonSerializer(TestCase):
             },
             {
                 "type": "record",
+                "namespace": "example.avro",
                 "name": "rec2",
                 "fields": [
                     {
@@ -213,7 +215,7 @@ class TestAvroJsonSerializer(TestCase):
             }
         }
         avro_json = AvroJsonSerializer(avro_schema).to_json(data)
-        self.assertEquals(avro_json, """{"funion_rec":{"rec1":{"field":1}}}""")
+        self.assertEquals(avro_json, """{"funion_rec":{"example.avro.rec1":{"field":1}}}""")
 
         data_another_record = {
             "funion_rec": {
@@ -221,7 +223,7 @@ class TestAvroJsonSerializer(TestCase):
             }
         }
         another_record_json = AvroJsonSerializer(avro_schema).to_json(data_another_record)
-        self.assertEquals(another_record_json, """{"funion_rec":{"rec2":{"field":"hi"}}}""")
+        self.assertEquals(another_record_json, """{"funion_rec":{"example.avro.rec2":{"field":"hi"}}}""")
 
     def test_map(self):
         schema_dict = {

--- a/avro_json_serializer/test/test_avro_json_serializer.py
+++ b/avro_json_serializer/test/test_avro_json_serializer.py
@@ -103,7 +103,6 @@ class TestAvroJsonSerializer(TestCase):
         "type": [
             {
                 "type": "record",
-                "namespace": "example.avro",
                 "name": "rec1",
                 "fields": [
                     {
@@ -215,7 +214,7 @@ class TestAvroJsonSerializer(TestCase):
             }
         }
         avro_json = AvroJsonSerializer(avro_schema).to_json(data)
-        self.assertEquals(avro_json, """{"funion_rec":{"example.avro.rec1":{"field":1}}}""")
+        self.assertEquals(avro_json, """{"funion_rec":{"rec1":{"field":1}}}""")
 
         data_another_record = {
             "funion_rec": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 avro==1.7.6; python_version < '3.0'
 avro-python3==1.8.1; python_version >= '3.0'
-simplejson
+simplejson; python_version < '2.7'
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-avro==1.7.6; python_version < '3.0'
-avro-python3==1.8.1; python_version >= '3.0'
+avro==1.8.2; python_version < '3.0'
+avro-python3==1.8.2; python_version >= '3.0'
 simplejson; python_version < '2.7'
 six

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ if version_info[:2] < (2, 7):
     install_requires.append('simplejson >= 2.0.9')
 
 if version_info[:2] <= (3, 0):
-    install_requires.append('avro==1.7.6')
+    install_requires.append('avro==1.8.2')
 else:
-    install_requires.append('avro-python3==1.8.1')
+    install_requires.append('avro-python3==1.8.2')
 
 setuptools.setup(
         name='avro_json_serializer',

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,14 @@ from sys import version_info
 
 # Project uses OrderedDict which is part of Python Standard Library
 # since version 2.7. On older versions, this is provided by simplejson.
-install_requires = []
-if version_info[:2] <= (2, 7):
+install_requires = ['six']
+if version_info[:2] < (2, 7):
     install_requires.append('simplejson >= 2.0.9')
+
+if version_info[:2] <= (3, 0):
+    install_requires.append('avro==1.7.6')
+else:
+    install_requires.append('avro-python3==1.8.1')
 
 setuptools.setup(
         name='avro_json_serializer',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py35
+[testenv]
+deps=nose
+commands=nosetests


### PR DESCRIPTION
This is related to pull request #2 and resolves an additional python3 incompatibility I found during a merge.

Using the `fullname` value with "avro-python3" was producing this erroneous output when a namespace was not provided. Example below (note the leading period).
```
{"funion_rec":{".rec1":{"field":1}}}
```