### PR TITLE
AvroJsonDeserializer class for json -> dict

### DIFF
--- a/avro_json_serializer/__init__.py
+++ b/avro_json_serializer/__init__.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License"); 
 # you may not use this file except in compliance with the License. 
 # You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
- 
+
 # Unless required by applicable law or agreed to in writing, software 
 # distributed under the License is distributed on an "AS IS" BASIS, 
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ if six.PY2:
     from avro.io import validate
 else:
     from avro.io import Validate as validate
+    basestring = str
 
 try:
     from collections import OrderedDict
@@ -35,13 +36,9 @@ except ImportError:
     from simplejson.ordered_dict import OrderedDict
 
 
-class AvroJsonSerializer(object):
+class AvroJsonBase(object):
     """
-    Use this class for avro json serialization:
-
-        serializer = AvroJsonSerializer(avro_schema)
-        serializer.to_json(data)
-
+    Base class for both serializer and deserializer classes.
     """
 
     """
@@ -54,41 +51,50 @@ class AvroJsonSerializer(object):
     """
     JSON_CHARSET = "utf-8"
 
+    """
+    No need to serialize primitives
+    """
+    PRIMITIVE_CONVERTERS = frozenset((
+        "boolean",
+        "string",
+        "int",
+        "long",
+        "float",
+        "double",
+        "enum"
+    ))
+
     def __init__(self, avro_schema):
         """
         :param avro_schema: instance of `avro.schema.Schema`
         """
         self._avro_schema = avro_schema
+        self.COMPLEX_CONVERTERS = {
+            "null": self._process_null,
+            "array": self._process_array,
+            "map": self._process_map,
+        }
 
-    def _serialize_binary_string(self, avro_schema, datum):
+    def _process_null(self, *args):
         """
-        `fixed` and `bytes` datum  are serialized as "ISO-8859-1", but we need to re-encode it to UTF-8 for JSON in Python 2.
-        """
-        string = datum.decode(self.BYTES_CHARSET)
-        if six.PY2:
-            string = string.encode(self.JSON_CHARSET)
-        return string
-
-    def _serialize_null(self, *args):
-        """
-        Always serialize into None, which will be serialized into "null" in json.
+        Always produce None, which will be (de)serialized into "null" in json.
         """
         return None
 
-    def _serialize_array(self, schema, datum):
+    def _process_array(self, schema, datum):
         """
-        Array is serialized into array.
-        Every element is serialized recursively according to `items` schema.
+        Array is (de)serialized into array.
+        Every element is processed recursively according to `items` schema.
         :param schema: Avro schema of `datum`
         :param datum: Data to serialize
         :return: serialized array (list)
         """
         if datum is None:
             raise AvroTypeException(schema, datum)
-        serialize = functools.partial(self._serialize_data, schema.items)
-        return list(map(serialize, datum))
+        process = functools.partial(self._process_data, schema.items)
+        return list(map(process, datum))
 
-    def _serialize_map(self, schema, datum):
+    def _process_map(self, schema, datum):
         """
         Map is serialized into a map.
         Every value is serialized recursively according to `values` schema.
@@ -98,8 +104,83 @@ class AvroJsonSerializer(object):
         """
         if datum is None:
             raise AvroTypeException(schema, datum)
-        serialize = functools.partial(self._serialize_data, schema.values)
-        return dict((key, serialize(value)) for key, value in six.iteritems(datum))
+        process = functools.partial(self._process_data, schema.values)
+        return dict((key, process(value)) for key, value in six.iteritems(datum))
+
+    def _union_name(self, schema):
+        """
+        Produce the type name for a union of the given schema.
+        :param schema: Avro schema for a value
+        :return: string containing the schema type or name
+        """
+        name = schema.type
+        if isinstance(schema, avro.schema.NamedSchema):
+            if schema.namespace:
+                name = schema.fullname
+            else:
+                name = schema.name
+        return name
+
+    def _validate(self, schema, datum):
+        """
+        Validate a datum matches a schema.
+        :param schema: Avro schema to match against the `datum`
+        :param datum: Data to validate
+        """
+        return validate(schema, datum)
+
+    def _process_data(self, schema, datum):
+        """
+        Non-specific serialize function.
+        It checks type in the schema and calls correct (de)serialization.
+        :param schema: Avro schema of the `datum`
+        :param datum: Data to process
+        """
+        if not self._validate(schema, datum):
+            raise AvroTypeException(schema, datum)
+
+        if schema.type in self.PRIMITIVE_CONVERTERS:
+            return datum
+
+        if schema.type in self.COMPLEX_CONVERTERS:
+            return self.COMPLEX_CONVERTERS[schema.type](schema, datum)
+
+        raise avro.schema.AvroException("Unknown type: %s" % schema.type)
+
+
+class AvroJsonSerializer(AvroJsonBase):
+    """
+    Use this class for avro json serialization:
+
+        serializer = AvroJsonSerializer(avro_schema)
+        serializer.to_json(data)
+
+    """
+
+    def __init__(self, avro_schema):
+        """
+        :param avro_schema: instance of `avro.schema.Schema`
+        """
+        super(AvroJsonSerializer, self).__init__(avro_schema)
+        self.COMPLEX_CONVERTERS.update({
+            "union": self._serialize_union,
+            "error_union": self._serialize_union,
+            "record": self._serialize_record,
+            "request": self._serialize_record,
+            "error": self._serialize_record,
+            "fixed": self._serialize_binary_string,
+            "bytes": self._serialize_binary_string
+        })
+
+    def _serialize_binary_string(self, schema, datum):
+        """
+        The `fixed` and `bytes` datum  are serialized as "ISO-8859-1", but we
+        need to re-encode it to UTF-8 for JSON in Python 2.
+        """
+        string = datum.decode(self.BYTES_CHARSET)
+        if six.PY2:
+            string = string.encode(self.JSON_CHARSET)
+        return string
 
     def _serialize_union(self, schema, datum):
         """
@@ -115,21 +196,16 @@ class AvroJsonSerializer(object):
         :param datum: Data to serialize
         :return: dict {"type": value} or "null"
         """
-        for candiate_schema in schema.schemas:
-            if validate(candiate_schema, datum):
-                if candiate_schema.type == "null":
-                    return self._serialize_null()
+        for candidate_schema in schema.schemas:
+            if validate(candidate_schema, datum):
+                if candidate_schema.type == "null":
+                    return self._process_null()
                 else:
-                    field_type_name = candiate_schema.type
-                    if isinstance(candiate_schema, avro.schema.NamedSchema):
-                        if candiate_schema.namespace:
-                            field_type_name = candiate_schema.fullname
-                        else:
-                            field_type_name = candiate_schema.name
+                    field_type_name = self._union_name(candidate_schema)
                     return {
-                        field_type_name: self._serialize_data(candiate_schema, datum)
+                        field_type_name: self._process_data(candidate_schema, datum)
                     }
-        raise schema.AvroTypeException(schema, datum)
+        raise AvroTypeException(schema, datum)
 
     def _serialize_record(self, schema, datum):
         """
@@ -140,58 +216,156 @@ class AvroJsonSerializer(object):
         """
         result = OrderedDict()
         for field in schema.fields:
-            result[field.name] = self._serialize_data(field.type, datum.get(field.name))
+            result[field.name] = self._process_data(field.type, datum.get(field.name))
         return result
 
-    """No need to serialize primitives
-    """
-    PRIMITIVE_CONVERTERS = frozenset((
-        "boolean",
-        "string",
-        "int",
-        "long",
-        "float",
-        "double",
-        "enum"
-    ))
-
-    """Some conversions require custom logic so we have separate functions for them.
-    """
-    COMPLEX_CONVERTERS = {
-        "null": _serialize_null,
-        "array": _serialize_array,
-        "map": _serialize_map,
-        "union": _serialize_union,
-        "error_union": _serialize_union,
-        "record": _serialize_record,
-        "request": _serialize_record,
-        "error": _serialize_record,
-        "fixed": _serialize_binary_string,
-        "bytes": _serialize_binary_string
-    }
-
-    def _serialize_data(self, schema, datum):
-        """
-        Non-specific serialize function.
-        It checks type in the schema and calls correct serialization.
-        :param schema: Avro schema of the `datum`
-        :param datum: Data to serialize
-        """
-        if not validate(schema, datum):
-            raise AvroTypeException(schema, datum)
-
-        if schema.type in AvroJsonSerializer.PRIMITIVE_CONVERTERS:
-            return datum
-
-        if schema.type in AvroJsonSerializer.COMPLEX_CONVERTERS:
-            return self.COMPLEX_CONVERTERS[schema.type](self, schema, datum)
-
-        raise avro.schema.AvroException("Unknown type: %s" % schema.type)
-
     def to_ordered_dict(self, datum):
-        return self._serialize_data(self._avro_schema, datum)
+        return self._process_data(self._avro_schema, datum)
 
     def to_json(self, datum):
         result = self.to_ordered_dict(datum)
         # we use separators to minimize size of the output string
         return json.dumps(result, separators=(",", ":"))
+
+
+class AvroJsonDeserializer(AvroJsonBase):
+    """
+    Use this class for avro json deserialization:
+
+        deserializer = AvroJsonDeserializer(avro_schema)
+        deserializer.from_json(data)
+
+    """
+
+    """Internally used to distinguish from "null" values on dict.get."""
+    class UnsetValue(object):
+        pass
+    UNSET = UnsetValue()
+
+    def __init__(self, avro_schema):
+        """
+        :param avro_schema: instance of `avro.schema.Schema`
+        """
+        super(AvroJsonDeserializer, self).__init__(avro_schema)
+        self.COMPLEX_CONVERTERS.update({
+            "union": self._deserialize_union,
+            "error_union": self._deserialize_union,
+            "record": self._deserialize_record,
+            "request": self._deserialize_record,
+            "error": self._deserialize_record,
+            "fixed": self._deserialize_binary_string,
+            "bytes": self._deserialize_binary_string
+        })
+
+    def _deserialize_binary_string(self, schema, datum):
+        """
+        `fixed` and `bytes` datum are serialized as "ISO-8859-1".
+        """
+        # assume byte types are already in ISO-8859-1
+        if isinstance(datum, bytes):
+            return datum
+
+        # otherwise assume unicode string that must be encoded
+        return datum.encode(self.BYTES_CHARSET)
+
+    def _deserialize_union(self, schema, datum):
+        """
+        With union schema has multiple possible schemas.
+        We iterate over possible schemas and see which one fits `datum` passed.
+        Union serialization:
+        if null:
+            "null"
+        else:
+            {"<type>": value}
+        Then used one that matches to serialize `datum`
+        :param schema: Avro schema for this union
+        :param datum: Data to serialize
+        :return: dict {"type": value} or "null"
+        """
+        for candidate_schema in schema.schemas:
+            if self._validate_union(candidate_schema, datum):
+                if candidate_schema.type == "null":
+                    return self._process_null()
+                else:
+                    field_type_name = self._union_name(candidate_schema)
+                    return datum[field_type_name]
+        raise AvroTypeException(schema, datum)
+
+    def _deserialize_record(self, schema, datum):
+        """
+        Records are serialized into ordered dicts in the order of fields in the schema.
+        Every field value is serialized based on it's schema.
+        :param schema: Avro schema of this record
+        :param datum: Data to serialize
+        """
+        result = OrderedDict()
+        for field in schema.fields:
+            result[field.name] = self._process_data(field.type, datum.get(field.name, self.UNSET))
+        return result
+
+    def _validate(self, schema, datum):
+        """
+        Validate a datum matches a schema.
+        :param schema: Avro schema to match against the `datum`
+        :param datum: Data to validate
+        """
+        if datum == self.UNSET:
+            return False
+
+        schema_type = schema.type
+
+        # Deserialized as unicode, convert to str for avro validation
+        if schema_type in ['fixed', 'bytes']:
+            datum = self._deserialize_binary_string(schema, datum)
+
+        # From the `avro.io.Validate` function in avro-python3.
+        # Recursive calls replaced so missing field values and binary fields in containers
+        # are handled properly (see self.UNSET and above binary handling).
+        if schema_type == 'array':
+            return (isinstance(datum, list) and
+                    all(self._validate(schema.items, d) for d in datum))
+        elif schema_type == 'map':
+            return (isinstance(datum, dict) and
+                    all(isinstance(k, basestring) for k in datum.keys()) and
+                    all(self._validate(schema.values, v) for v in datum.values()))
+        elif schema_type in ['union', 'error_union']:
+            return any(self._validate_union(s, datum) for s in schema.schemas)
+        elif schema_type in ['record', 'error', 'request']:
+            return (isinstance(datum, dict) and
+                    all(self._validate(f.type, datum.get(f.name, self.UNSET))
+                        for f in schema.fields))
+
+        return validate(schema, datum)
+
+    def _validate_union(self, schema, datum):
+        """
+        Validate a wrapped union value, which might be None.
+        :param schema: Avro schema of the `datum`
+        :param datum: dict deserialized from json
+        """
+        if datum == self.UNSET:
+            return False
+
+        wrapped_datum = datum
+        name = self._union_name(schema)
+        if datum and name in datum:
+            wrapped_datum = datum[name]
+        return self._validate(schema, wrapped_datum)
+
+    def from_dict(self, datum):
+        """
+        Deserialize an Avro dict that was deserialized by the json library.
+        :param schema: Avro schema of the `datum`
+        :param datum: validated python dict object
+        """
+        # asssume data has been deserialized already
+        return self._process_data(self._avro_schema, datum)
+
+    def from_json(self, datum):
+        """
+        Deserialize an Avro json string.
+        :param schema: Avro schema of the `datum`
+        :param datum: string of serialized
+        """
+        # json library does the bulk of the work
+        return self.from_dict(json.loads(datum))

--- a/avro_json_serializer/__init__.py
+++ b/avro_json_serializer/__init__.py
@@ -288,7 +288,7 @@ class AvroJsonDeserializer(AvroJsonBase):
                     return self._process_null()
                 else:
                     field_type_name = self._union_name(candidate_schema)
-                    return datum[field_type_name]
+                    return self._process_data(candidate_schema, datum[field_type_name])
         raise AvroTypeException(schema, datum)
 
     def _deserialize_record(self, schema, datum):

--- a/avro_json_serializer/test/test_avro_json_serializer.py
+++ b/avro_json_serializer/test/test_avro_json_serializer.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License"); 
 # you may not use this file except in compliance with the License. 
 # You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
- 
+
 # Unless required by applicable law or agreed to in writing, software 
 # distributed under the License is distributed on an "AS IS" BASIS, 
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,17 +20,20 @@ else:
     from avro.schema import SchemaFromJSONData as make_avsc_object
     long = int
 
-from avro_json_serializer import AvroJsonSerializer
+from avro_json_serializer import AvroJsonSerializer, AvroJsonDeserializer
 
 class TestAvroJsonSerializer(TestCase):
     FIELD_ENUM = {
-        "type": "enum",
-        "symbols": [
-            "ORANGE",
-            "APPLE",
-            "PINEAPPLE"
-        ],
-        "name": "fruit"
+        "name": "fruit",
+        "type": {
+            "name": "Fruit",
+            "type": "enum",
+            "symbols": [
+                "ORANGE",
+                "APPLE",
+                "PINEAPPLE"
+            ]
+        }
     }
 
     FIELD_INT = {
@@ -129,6 +132,7 @@ class TestAvroJsonSerializer(TestCase):
         "type": "record",
         "name": "all_field",
         "fields": [
+            FIELD_ENUM,
             FIELD_INT,
             FIELD_LONG,
             FIELD_STRING,
@@ -136,7 +140,9 @@ class TestAvroJsonSerializer(TestCase):
             FIELD_RECORD,
             FIELD_UNION_NULL_INT,
             FIELD_FLOAT,
-            FIELD_DOUBLE
+            FIELD_DOUBLE,
+            FIELD_ARRAY_INT,
+            FIELD_MAP_INT
         ],
         "namespace": "com.some.thing"
     }
@@ -158,6 +164,7 @@ class TestAvroJsonSerializer(TestCase):
     }
 
     VALID_DATA_ALL_FIELDS = {
+        "fruit": "ORANGE",
         "fint": 1,
         "flong": long(1),
         "ffloat": 1.0,
@@ -167,13 +174,34 @@ class TestAvroJsonSerializer(TestCase):
         "frec": {
             "subfint": 2
         },
-        "funion_null": None
+        "funion_null": None,
+        "intarr": [1, 2, 3],
+        "intmap": {"one": 1}
     }
+
+    # unions can't be serialized directly; must be in a record
+    INDIVIDUALLY_SERIALIZABLE = list(ALL_FIELDS_SCHEMA['fields'])
+    INDIVIDUALLY_SERIALIZABLE.remove(FIELD_UNION_NULL_INT)
 
     def test_all_supported_types(self):
         avro_schema = make_avsc_object(self.ALL_FIELDS_SCHEMA, avro.schema.Names())
-        avro_json = AvroJsonSerializer(avro_schema).to_json(self.VALID_DATA_ALL_FIELDS)
-        self.assertEquals(avro_json, """{"fint":1,"flong":1,"fstring":"hi there","ffixed":"1234567890123456","frec":{"subfint":2},"funion_null":null,"ffloat":1.0,"fdouble":2.0}""")
+        data = self.VALID_DATA_ALL_FIELDS
+        avro_json = AvroJsonSerializer(avro_schema).to_json(data)
+        self.assertEquals(avro_json, """{"fruit":"ORANGE","fint":1,"flong":1,"fstring":"hi there","ffixed":"1234567890123456","frec":{"subfint":2},"funion_null":null,"ffloat":1.0,"fdouble":2.0,"intarr":[1,2,3],"intmap":{"one":1}}""")
+        json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+        self.assertEquals(json_data, data)
+
+    def test_individually_allowed_fields_separately(self):
+        for field in self.INDIVIDUALLY_SERIALIZABLE:
+            # unwrap enum, fixed, array, and map but save the name for value lookup
+            name = field['name']
+            if isinstance(field['type'], dict):
+                field = field['type']
+            avro_schema = make_avsc_object(field, avro.schema.Names())
+            data = self.VALID_DATA_ALL_FIELDS[name]
+            avro_json = AvroJsonSerializer(avro_schema).to_json(data)
+            json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+            self.assertEquals(json_data, data)
 
     def test_fails_validation(self):
         avro_schema = make_avsc_object(self.ALL_FIELDS_SCHEMA, avro.schema.Names())
@@ -189,6 +217,8 @@ class TestAvroJsonSerializer(TestCase):
         }
         avro_json = AvroJsonSerializer(avro_schema).to_json(data)
         self.assertEquals(avro_json, """{"funion_null":null}""")
+        json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+        self.assertEquals(json_data, data)
 
     def test_union_serialization_not_null(self):
         avro_schema = make_avsc_object(self.UNION_FIELDS_SCHEMA, avro.schema.Names())
@@ -197,6 +227,8 @@ class TestAvroJsonSerializer(TestCase):
         }
         avro_json = AvroJsonSerializer(avro_schema).to_json(data)
         self.assertEquals(avro_json, """{"funion_null":{"int":1}}""")
+        json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+        self.assertEquals(json_data, data)
 
     def test_union_serialization_invalid(self):
         avro_schema = make_avsc_object(self.UNION_FIELDS_SCHEMA, avro.schema.Names())
@@ -215,6 +247,8 @@ class TestAvroJsonSerializer(TestCase):
         }
         avro_json = AvroJsonSerializer(avro_schema).to_json(data)
         self.assertEquals(avro_json, """{"funion_rec":{"rec1":{"field":1}}}""")
+        json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+        self.assertEquals(json_data, data)
 
         data_another_record = {
             "funion_rec": {
@@ -223,6 +257,8 @@ class TestAvroJsonSerializer(TestCase):
         }
         another_record_json = AvroJsonSerializer(avro_schema).to_json(data_another_record)
         self.assertEquals(another_record_json, """{"funion_rec":{"example.avro.rec2":{"field":"hi"}}}""")
+        another_json_data = AvroJsonDeserializer(avro_schema).from_json(another_record_json)
+        self.assertEquals(another_json_data, data_another_record)
 
     def test_map(self):
         schema_dict = {
@@ -238,11 +274,25 @@ class TestAvroJsonSerializer(TestCase):
                 "two": 2
             }
         }
+        unicode_dict = {
+            'intmap': {
+                'one': 1,
+                u'two': 2
+            }
+        }
+
         avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
         avro_json = AvroJsonSerializer(avro_schema).to_json(data)
 
         # Dictionaries are unsorted
         self.assertIn(avro_json, ("""{"intmap":{"one":1,"two":2}}""", """{"intmap":{"two":2,"one":1}}"""))
+
+        deserializer = AvroJsonDeserializer(avro_schema)
+        json_data = deserializer.from_json(avro_json)
+        self.assertEquals(json_data, data)
+
+        mixed_unicode = deserializer.from_dict(unicode_dict)
+        self.assertEquals(mixed_unicode, data)
 
     def test_array(self):
         schema_dict = {
@@ -258,6 +308,8 @@ class TestAvroJsonSerializer(TestCase):
         avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
         avro_json = AvroJsonSerializer(avro_schema).to_json(data)
         self.assertEquals(avro_json, """{"intarr":[1,2,3]}""")
+        json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+        self.assertEquals(json_data, data)
 
     def test_user_record(self):
         """
@@ -265,22 +317,31 @@ class TestAvroJsonSerializer(TestCase):
         """
         schema_dict = {
             "namespace": "example.avro",
-                  "type": "record",
-                  "name": "User",
-                  "fields": [
-                      {"name": "name", "type": "string"},
-                      {"name": "favorite_number",  "type": ["int", "null"]},
-                      {"name": "favorite_color", "type": ["string", "null"]}
-                  ]
+            "type": "record",
+            "name": "User",
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "favorite_number",  "type": ["int", "null"]},
+                {"name": "favorite_color", "type": ["string", "null"]}
+            ]
         }
         avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
         serializer = AvroJsonSerializer(avro_schema)
-        self.assertEquals(serializer.to_json({"name": "Alyssa", "favorite_number": 256}),
-                          """{"name":"Alyssa","favorite_number":{"int":256},"favorite_color":null}""")
-        self.assertEquals(serializer.to_json({"name": "Ben", "favorite_number": 7, "favorite_color": "red"}),
-                          """{"name":"Ben","favorite_number":{"int":7},"favorite_color":{"string":"red"}}""")
-        self.assertEquals(serializer.to_json({"name": "Lion"}),
-                          """{"name":"Lion","favorite_number":null,"favorite_color":null}""")
+        deserializer = AvroJsonDeserializer(avro_schema)
+        alyssa = {"name": "Alyssa", "favorite_number": 256}
+        alyssa_full = {"name": "Alyssa", "favorite_number": 256, "favorite_color": None}
+        alyssa_json = """{"name":"Alyssa","favorite_number":{"int":256},"favorite_color":null}"""
+        self.assertEquals(serializer.to_json(alyssa), alyssa_json)
+        self.assertEquals(deserializer.from_json(alyssa_json), alyssa_full)
+        ben = {"name": "Ben", "favorite_number": 7, "favorite_color": "red"}
+        ben_json = """{"name":"Ben","favorite_number":{"int":7},"favorite_color":{"string":"red"}}"""
+        self.assertEquals(serializer.to_json(ben), ben_json)
+        self.assertEquals(deserializer.from_json(ben_json), ben)
+        lion = {"name": "Lion"}
+        lion_full = {"name": "Lion", "favorite_number": None, "favorite_color": None}
+        lion_json = """{"name":"Lion","favorite_number":null,"favorite_color":null}"""
+        self.assertEquals(serializer.to_json(lion), lion_json)
+        self.assertEquals(deserializer.from_json(lion_json), lion_full)
 
     def test_fixed_non_ascii(self):
         schema_dict = {
@@ -294,8 +355,10 @@ class TestAvroJsonSerializer(TestCase):
         data = {"ffixed": b"(~^\xfbzoW\x13p\x19!4\x0b+\x00\x00"}
         avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
         serializer = AvroJsonSerializer(avro_schema)
-        json_data = serializer.to_json(data)
-        self.assertEquals(json_data, """{"ffixed":"(~^\\u00fbzoW\\u0013p\\u0019!4\\u000b+\\u0000\\u0000"}""")
+        avro_json = serializer.to_json(data)
+        self.assertEquals(avro_json, """{"ffixed":"(~^\\u00fbzoW\\u0013p\\u0019!4\\u000b+\\u0000\\u0000"}""")
+        json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+        self.assertEquals(json_data, data)
 
     def test_fixed_ascii(self):
         schema_dict = {
@@ -309,9 +372,10 @@ class TestAvroJsonSerializer(TestCase):
         data = {"ffixed": b"fixed text here!"}
         avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
         serializer = AvroJsonSerializer(avro_schema)
-        json_data = serializer.to_json(data)
-        self.assertEquals(json_data, """{"ffixed":"fixed text here!"}""")
-
+        avro_json = serializer.to_json(data)
+        self.assertEquals(avro_json, """{"ffixed":"fixed text here!"}""")
+        json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+        self.assertEquals(json_data, data)
 
     def test_bytes_field_non_ascii(self):
         schema_dict = {
@@ -328,8 +392,10 @@ class TestAvroJsonSerializer(TestCase):
         data = {"fbytes": b"(~^\xfbzoW\x13p\x19!4\x0b+\x00\x00\x0b+\x00\x00"}
         avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
         serializer = AvroJsonSerializer(avro_schema)
-        json_data = serializer.to_json(data)
-        self.assertEquals(json_data, """{"fbytes":"(~^\\u00fbzoW\\u0013p\\u0019!4\\u000b+\\u0000\\u0000\\u000b+\\u0000\\u0000"}""")
+        avro_json = serializer.to_json(data)
+        self.assertEquals(avro_json, """{"fbytes":"(~^\\u00fbzoW\\u0013p\\u0019!4\\u000b+\\u0000\\u0000\\u000b+\\u0000\\u0000"}""")
+        json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+        self.assertEquals(json_data, data)
 
     def test_bytes_field_ascii(self):
         schema_dict = {
@@ -346,5 +412,69 @@ class TestAvroJsonSerializer(TestCase):
         data = {"fbytes": b"this is some long bytes field"}
         avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
         serializer = AvroJsonSerializer(avro_schema)
-        json_data = serializer.to_json(data)
-        self.assertEquals(json_data, """{"fbytes":"this is some long bytes field"}""")
+        avro_json = serializer.to_json(data)
+        self.assertEquals(avro_json, """{"fbytes":"this is some long bytes field"}""")
+        json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+        self.assertEquals(json_data, data)
+
+
+class TestAvroJsonDeserializer(TestCase):
+    def test_missing_nullable_field(self):
+        schema_dict = {
+            "type": "record",
+            "name": "WithDefault",
+            "fields": [
+                {
+                    "type": "string",
+                    "name": "name"
+                },
+                {
+                    "type": ["null", "int"],
+                    "name": "version",
+                    "default": None
+                }
+            ]
+        }
+        avro_json = """{"name":"mcnameface"}"""
+        avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
+        deserializer = AvroJsonDeserializer(avro_schema)
+        self.assertRaises(avro.io.AvroTypeException, deserializer.from_json, avro_json)
+
+    def test_unknown_fields_are_ignored(self):
+        schema_dict = {
+            "type": "record",
+            "name": "BasicName",
+            "fields": [
+                {
+                    "type": "string",
+                    "name": "name"
+                }
+            ]
+        }
+        avro_json = """{"name":"todd","age":1}"""
+        avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
+        json_data = AvroJsonDeserializer(avro_schema).from_json(avro_json)
+        self.assertEquals(json_data, {"name": "todd"})
+
+    def test_dict_with_unicode_bytes(self):
+        schema_dict = {
+            "namespace": "example.avro",
+            "type": "record",
+            "name": "WithBytes",
+            "fields": [
+                {
+                    "type": "bytes",
+                    "name": "fbytes"
+                }
+            ]
+        }
+
+        # byte arrays should be left alone
+        byte_data = {"fbytes": b"(~^\xfbzoW\x13p\x19!4\x0b+\x00\x00\x0b+\x00\x00"}
+        avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
+        self.assertEquals(AvroJsonDeserializer(avro_schema).from_dict(byte_data), byte_data)
+
+        # unicode strings should be turned into iso-8859-1 bytes
+        iso8859_data = {'fbytes': b"(~^\xfbzoW\x13p\x19!4\x0b+\x00\x00"}
+        unicode_data = {u'fbytes': u'(~^\xfbzoW\x13p\x19!4\x0b+\x00\x00'}
+        self.assertEquals(AvroJsonDeserializer(avro_schema).from_dict(unicode_data), iso8859_data)


### PR DESCRIPTION
This is an implementation for #5.

Adds a class for going from the serialized json back to a plain old python object. This implementation does not support separate reader/writer schemas but will perform schema validation and will strip unknown fields from the input (similar to the way the java decoder works).

A bunch of patterns from the serializer class applied to writing the deserializer, so I moved common code into the `AvroJsonBase` class and tried to reuse things as much as possible.

Serializer tests are identical with a few exceptions:
  - Fixed enum schema and hooked up move fields into the "all" test
  - Wrote a test for all the base types that the java serializer happily serializes
  - Hooked up the deserializer for all the produced json
  - special python2/python3 edge case in map test