### PR TITLE
Loosen the avro dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-avro==1.8.2; python_version < '3.0'
-avro-python3==1.8.2; python_version >= '3.0'
+avro>=1.8.2,<1.10.0; python_version < '3.0'
+avro-python3>=1.8.2,<2; python_version >= '3.0'
+nose
 simplejson; python_version < '2.7'
 six

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ setuptools.setup(
             # Project uses OrderedDict which is part of Python Standard Library
             # since version 2.7. On older versions, this is provided by simplejson.
             ':python_version<="2.7"': ['simplejson>=2.0.9'],
-            ':python_version<="3.0"': ['avro==1.8.2'],
-            ':python_version>"3.0"': ['avro-python3==1.8.2'],
+            ':python_version<="3.0"': ['avro>=1.8.2,<1.10.0'],
+            ':python_version>"3.0"': ['avro-python3>=1.8.2,<2'],
         },
         packages = ['avro_json_serializer'],
         license = 'Apache 2.0'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py35,py36,py37,py38
 [testenv]
-deps=nose
+deps=-rrequirements.txt
 commands=nosetests


### PR DESCRIPTION
We're starting to hit more dependencies that depend on newer versions of `avro-python3`.

This loosens the avro dependencies to those that pass the unit tests, keeping the upper range pretty open for `avro-python3`.

The tests didn't pass with `python2.7` and `avro==1.10.0`, so I limited that particular range a bit further. Since Python 2.7 is at end-of-life, it doesn't make sense to put in more effort on fixing that.