### PR TITLE
Deprecate avro python 3

### DIFF
--- a/avro_json_serializer/__init__.py
+++ b/avro_json_serializer/__init__.py
@@ -138,9 +138,6 @@ class AvroJsonBase(object):
         :param schema: Avro schema of the `datum`
         :param datum: Data to process
         """
-        print("Datum: {}".format(datum))
-        print("Schema: {}".format(schema))
-
         if not self._validate(schema, datum):
             raise AvroTypeException(schema, datum)
 

--- a/avro_json_serializer/__init__.py
+++ b/avro_json_serializer/__init__.py
@@ -19,17 +19,16 @@ import functools
 import json
 
 import avro.schema
-from avro.io import AvroTypeException
+from avro.errors import AvroTypeException
 import six
-
 
 try:
     from avro.io import validate
 except ImportError:
     from avro.io import Validate as validate
 
-    if six.PY3:
-        basestring = str
+if six.PY3:
+    basestring = str
 
 try:
     from collections import OrderedDict
@@ -139,6 +138,9 @@ class AvroJsonBase(object):
         :param schema: Avro schema of the `datum`
         :param datum: Data to process
         """
+        print("Datum: {}".format(datum))
+        print("Schema: {}".format(schema))
+
         if not self._validate(schema, datum):
             raise AvroTypeException(schema, datum)
 

--- a/avro_json_serializer/__init__.py
+++ b/avro_json_serializer/__init__.py
@@ -25,15 +25,12 @@ if six.PY2:
     from avro.io import AvroTypeException
 else:
     from avro.errors import AvroTypeException
-import six
+    basestring = str
 
 try:
     from avro.io import validate
 except ImportError:
     from avro.io import Validate as validate
-
-if six.PY3:
-    basestring = str
 
 try:
     from collections import OrderedDict

--- a/avro_json_serializer/__init__.py
+++ b/avro_json_serializer/__init__.py
@@ -17,9 +17,14 @@ Inspired by avro.io.DatumWriter (which writes binary avro)
 
 import functools
 import json
+import six
 
 import avro.schema
-from avro.errors import AvroTypeException
+
+if six.PY2:
+    from avro.io import AvroTypeException
+else:
+    from avro.errors import AvroTypeException
 import six
 
 try:

--- a/avro_json_serializer/test/test_avro_json_serializer.py
+++ b/avro_json_serializer/test/test_avro_json_serializer.py
@@ -17,7 +17,7 @@ from unittest import TestCase
 if six.PY2:
     from avro.schema import make_avsc_object
 else:
-    from avro.schema import SchemaFromJSONData as make_avsc_object
+    from avro.schema import make_avsc_object
     long = int
 
 from avro_json_serializer import AvroJsonSerializer, AvroJsonDeserializer
@@ -208,7 +208,7 @@ class TestAvroJsonSerializer(TestCase):
         data = dict(self.VALID_DATA_ALL_FIELDS)
         data["ffloat"] = "hi"
         serializer = AvroJsonSerializer(avro_schema)
-        self.assertRaises(avro.io.AvroTypeException, serializer.to_json, data)
+        self.assertRaises(avro.errors.AvroTypeException, serializer.to_json, data)
 
     def test_union_serialization_null(self):
         avro_schema = make_avsc_object(self.UNION_FIELDS_SCHEMA, avro.schema.Names())
@@ -236,7 +236,7 @@ class TestAvroJsonSerializer(TestCase):
             "funion_null": "hi"
         }
         serializer = AvroJsonSerializer(avro_schema)
-        self.assertRaises(avro.io.AvroTypeException, serializer.to_json, data)
+        self.assertRaises(avro.errors.AvroTypeException, serializer.to_json, data)
 
     def test_records_union(self):
         avro_schema = make_avsc_object(self.UNION_RECORDS_SCHEMA, avro.schema.Names())
@@ -476,7 +476,7 @@ class TestAvroJsonDeserializer(TestCase):
         avro_json = """{"name":"mcnameface"}"""
         avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
         deserializer = AvroJsonDeserializer(avro_schema)
-        self.assertRaises(avro.io.AvroTypeException, deserializer.from_json, avro_json)
+        self.assertRaises(avro.errors.AvroTypeException, deserializer.from_json, avro_json)
 
     def test_unknown_fields_are_ignored(self):
         schema_dict = {

--- a/avro_json_serializer/test/test_avro_json_serializer.py
+++ b/avro_json_serializer/test/test_avro_json_serializer.py
@@ -16,8 +16,10 @@ from unittest import TestCase
 
 if six.PY2:
     from avro.schema import make_avsc_object
+    from avro.io import AvroTypeException
 else:
     from avro.schema import make_avsc_object
+    from avro.errors import AvroTypeException
     long = int
 
 from avro_json_serializer import AvroJsonSerializer, AvroJsonDeserializer
@@ -208,7 +210,7 @@ class TestAvroJsonSerializer(TestCase):
         data = dict(self.VALID_DATA_ALL_FIELDS)
         data["ffloat"] = "hi"
         serializer = AvroJsonSerializer(avro_schema)
-        self.assertRaises(avro.errors.AvroTypeException, serializer.to_json, data)
+        self.assertRaises(AvroTypeException, serializer.to_json, data)
 
     def test_union_serialization_null(self):
         avro_schema = make_avsc_object(self.UNION_FIELDS_SCHEMA, avro.schema.Names())
@@ -236,7 +238,7 @@ class TestAvroJsonSerializer(TestCase):
             "funion_null": "hi"
         }
         serializer = AvroJsonSerializer(avro_schema)
-        self.assertRaises(avro.errors.AvroTypeException, serializer.to_json, data)
+        self.assertRaises(AvroTypeException, serializer.to_json, data)
 
     def test_records_union(self):
         avro_schema = make_avsc_object(self.UNION_RECORDS_SCHEMA, avro.schema.Names())
@@ -476,7 +478,7 @@ class TestAvroJsonDeserializer(TestCase):
         avro_json = """{"name":"mcnameface"}"""
         avro_schema = make_avsc_object(schema_dict, avro.schema.Names())
         deserializer = AvroJsonDeserializer(avro_schema)
-        self.assertRaises(avro.errors.AvroTypeException, deserializer.from_json, avro_json)
+        self.assertRaises(AvroTypeException, deserializer.from_json, avro_json)
 
     def test_unknown_fields_are_ignored(self):
         schema_dict = {

--- a/avro_json_serializer/test/test_avro_json_serializer.py
+++ b/avro_json_serializer/test/test_avro_json_serializer.py
@@ -120,7 +120,7 @@ class TestAvroJsonSerializer(TestCase):
                 "name": "rec2",
                 "fields": [
                     {
-                        "name": "field",
+                        "name": "field2",
                         "type": "string"
                     }
                 ]
@@ -252,11 +252,11 @@ class TestAvroJsonSerializer(TestCase):
 
         data_another_record = {
             "funion_rec": {
-                "field": "hi"
+                "field2": "hi"
             }
         }
         another_record_json = AvroJsonSerializer(avro_schema).to_json(data_another_record)
-        self.assertEquals(another_record_json, """{"funion_rec":{"example.avro.rec2":{"field":"hi"}}}""")
+        self.assertEquals(another_record_json, """{"funion_rec":{"example.avro.rec2":{"field2":"hi"}}}""")
         another_json_data = AvroJsonDeserializer(avro_schema).from_json(another_record_json)
         self.assertEquals(another_json_data, data_another_record)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 avro>=1.8.2,<1.10.0; python_version < '3.0'
-avro-python3>=1.8.2,<2; python_version >= '3.0'
+avro>=1.10.0,<2; python_version >= '3.0'
 nose
 simplejson; python_version < '2.7'
 six

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md") as f:
 
 setuptools.setup(
         name='avro_json_serializer',
-        version='1.0.4',
+        version='1.0.5',
         description='Avro Json Serializer',
         long_description=long_description,
         long_description_content_type="text/markdown",
@@ -30,7 +30,7 @@ setuptools.setup(
             # since version 2.7. On older versions, this is provided by simplejson.
             ':python_version<="2.7"': ['simplejson>=2.0.9'],
             ':python_version<="3.0"': ['avro>=1.8.2,<1.10.0'],
-            ':python_version>"3.0"': ['avro-python3>=1.8.2,<2'],
+            ':python_version>"3.0"': ['avro>=1.10.0,<2'],
         },
         packages = ['avro_json_serializer'],
         license = 'Apache 2.0'


### PR DESCRIPTION
avro-python3](https://pypi.org/project/avro-python3/) is no longer maintained and is deprecated in favor of [avro](https://pypi.org/project/avro/).

This PR follow up with this the deprecation and removes support for avro-python3